### PR TITLE
CRM457-1327: Get working with pub/sub and Ruby server

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -20,3 +20,5 @@ services:
   nscc-appstore:
     platform: ${LOCAL_PLATFORM}
     build: https://github.com/ministryofjustice/laa-crime-application-store.git#main
+    volumes:
+      - ./tmp/logs/appstore:/usr/src/app/log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,7 +83,7 @@ services:
       RAILS_ENV: development
       ENV: localhost
       RAILS_DEVELOPMENT_HOSTS: nscc-provider
-      HOSTS: 'nscc-provider:3000'
+      HOSTS: "nscc-provider:3000"
       PROTOCOL: http
       RAILS_LOG_TO_STDOUT: enabled
       APP_STORE_URL: http://nscc-appstore:3000
@@ -116,7 +116,7 @@ services:
       RAILS_ENV: development
       ENV: local
       RAILS_DEVELOPMENT_HOSTS: nscc-caseworker
-      HOSTS: 'nscc-caseworker:3000'
+      HOSTS: "nscc-caseworker:3000"
       PROTOCOL: http
       REDIS_URL: redis://nscc-redis:6379/2
       REDIS_PASSWORD: redis
@@ -149,9 +149,9 @@ services:
       SECRET_KEY_BASE: any-key
       RAILS_ENV: development
       RAILS_DEVELOPMENT_HOSTS: nscc-appstore
-      AUTHENTICATION_REQUIRED: 'false'
+      AUTHENTICATION_REQUIRED: "false"
       DATABASE_URL: postgresql://postgres:postgres@nscc-db-services:5432/laa_crime_application_store
-      RUN_SIDEKIQ_IN_TEST_MODE: 'true'
+      RUN_SIDEKIQ_IN_TEST_MODE: "true"
     depends_on:
       nscc-db-services:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,6 @@ services:
       -wait-retry-interval 10s
       -timeout 180s
     depends_on:
-      - nscc-db-services
       - nscc-provider
       - nscc-caseworker
       - nscc-redis
@@ -97,7 +96,6 @@ services:
       MAX_UPLOAD_SIZE_BYTES: 10485760
       GOVUK_NOTIFY_API_KEY: 12345
       RUN_SIDEKIQ_IN_TEST_MODE: true
-      ENABLE_SYNC_TRIGGER_ENDPOINT: true
     depends_on:
       - nscc-redis
       - nscc-db-services
@@ -133,7 +131,6 @@ services:
       DEV_AUTH_ENABLED: true
       GOVUK_NOTIFY_API_KEY: 12345
       RUN_SIDEKIQ_IN_TEST_MODE: true
-      ENABLE_SYNC_TRIGGER_ENDPOINT: true
     depends_on:
       - nscc-redis
       - nscc-db-services

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,21 +8,31 @@
 version: "3.9"
 
 services:
+  start_app_store:
+    container_name: start_app_store
+    image: jwilder/dockerize
+    command: >
+      -wait tcp://nscc-appstore:3000
+      -wait-retry-interval 10s
+      -timeout 180s
+    depends_on:
+      - nscc-db-services
+      - nscc-appstore
+
   start_applications:
     container_name: start_applications
     image: jwilder/dockerize
     command: >
       -wait tcp://nscc-provider:3000
       -wait tcp://nscc-caseworker:3000
-      -wait tcp://nscc-appstore:8000
       -wait-retry-interval 10s
       -timeout 180s
     depends_on:
       - nscc-db-services
       - nscc-provider
       - nscc-caseworker
-      - nscc-appstore
       - nscc-redis
+      - start_app_store
 
   laa-crime-forms-end-to-end-tests:
     container_name: laa-crime-forms-end-to-end-tests
@@ -68,12 +78,15 @@ services:
     ports:
       - 3001:3000
     environment: &providerenvironment
-      SECRET_KEY_BASE: needed_for_assets_precompile
-      RAILS_ENV: test
+      WORKERS: 3
+      SECRET_KEY_BASE: some-secret-key
+      RAILS_ENV: development
       ENV: localhost
       RAILS_DEVELOPMENT_HOSTS: nscc-provider
+      HOSTS: 'nscc-provider:3000'
+      PROTOCOL: http
       RAILS_LOG_TO_STDOUT: enabled
-      APP_STORE_URL: http://nscc-appstore:8000
+      APP_STORE_URL: http://nscc-appstore:3000
       REDIS_URL: redis://nscc-redis:6379/1
       REDIS_PASSWORD: redis
       SIDEKIQ_WEB_UI_USERNAME: sidekiq
@@ -86,10 +99,9 @@ services:
       RUN_SIDEKIQ_IN_TEST_MODE: true
       ENABLE_SYNC_TRIGGER_ENDPOINT: true
     depends_on:
-      nscc-redis:
-        condition: service_started
-      nscc-db-services:
-        condition: service_healthy
+      - nscc-redis
+      - nscc-db-services
+      - start_app_store
 
   # NSCC CASEWORKER service
 
@@ -99,10 +111,13 @@ services:
     ports:
       - 3002:3000
     environment: &caseworkerenvironment
-      SECRET_KEY_BASE: needed_for_assets_precompile
+      WORKERS: 3
+      SECRET_KEY_BASE: some-secret-key
       RAILS_ENV: development
       ENV: local
       RAILS_DEVELOPMENT_HOSTS: nscc-caseworker
+      HOSTS: 'nscc-caseworker:3000'
+      PROTOCOL: http
       REDIS_URL: redis://nscc-redis:6379/2
       REDIS_PASSWORD: redis
       RAILS_LOG_TO_STDOUT: enabled
@@ -114,30 +129,36 @@ services:
       OMNIAUTH_AZURE_CLIENT_SECRET: ""
       OMNIAUTH_AZURE_REDIRECT_URI: ""
       OMNIAUTH_AZURE_TENANT_ID: ""
-      APP_STORE_URL: http://nscc-appstore:8000
+      APP_STORE_URL: http://nscc-appstore:3000
       DEV_AUTH_ENABLED: true
       GOVUK_NOTIFY_API_KEY: 12345
       RUN_SIDEKIQ_IN_TEST_MODE: true
       ENABLE_SYNC_TRIGGER_ENDPOINT: true
     depends_on:
-      nscc-redis:
-        condition: service_started
-      nscc-db-services:
-        condition: service_healthy
+      - nscc-redis
+      - nscc-db-services
+      - start_app_store
 
   # NSCC Application Store service
 
   nscc-appstore:
     container_name: nscc-appstore
     image: ${NSCC_APPSTORE_IMAGE:-754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-crime-forms-team/laa-crime-application-store-dev:latest}
-    environment:
-      - AUTHENTICATION_REQUIRED=False
-      - POSTGRES_USERNAME=postgres
-      - POSTGRES_PASSWORD=postgres
-      - POSTGRES_HOSTNAME=nscc-db-services
-      - POSTGRES_NAME=laa_crime_application_store
+    environment: &appstoreenvironment
+      WORKERS: 3
+      SECRET_KEY_BASE: any-key
+      RAILS_ENV: development
+      RAILS_DEVELOPMENT_HOSTS: nscc-appstore
+      AUTHENTICATION_REQUIRED: 'false'
+      DATABASE_URL: postgresql://postgres:postgres@nscc-db-services:5432/laa_crime_application_store
+      RUN_SIDEKIQ_IN_TEST_MODE: 'true'
     depends_on:
       nscc-db-services:
         condition: service_healthy
+    healthcheck:
+      test: "curl -I  http://localhost:3000/ping | grep 200 || exit 1"
+      interval: 5s
+      timeout: 5s
+      retries: 20
     ports:
-      - 8000:8000
+      - 3003:3000

--- a/e2e/crm7/provider/submit-claim.spec.js
+++ b/e2e/crm7/provider/submit-claim.spec.js
@@ -181,8 +181,6 @@ export default function createTests() {
     });
 
     test('View claim in caseworker app', async () => {
-        await page.goto(caseworkerAppUrl('/sync') );
-
         await authenticateAsCaseworker(page);
 
         const allClaimsPage = new AllClaimsPage(page);
@@ -258,7 +256,6 @@ export default function createTests() {
     });
 
     test('View result as provider', async () => {
-        await page.goto(providerAppUrl('/sync') );
         await new YourClaimsPage(page).goto();
         await expect(page.locator('#main-content')).toContainText(`${laaReference} Granted`);
     });

--- a/run_test_local.sh
+++ b/run_test_local.sh
@@ -5,6 +5,9 @@ export DOCKER_FILES="-f docker-compose.yml -f docker-compose.local.yml"
 
 export DOCKER_BUILDKIT=0
 
+function start_app_store {
+  docker-compose $DOCKER_FILES run start_app_store
+}
 function start_applications {
   docker-compose $DOCKER_FILES run start_applications
 }
@@ -14,6 +17,7 @@ function run_tests {
 }
 
 docker-compose $DOCKER_FILES down
+start_app_store
 start_applications
 run_tests
 


### PR DESCRIPTION
- Add appropriate config for new Rails app store on port 3000
- Start app store before client apps so they can register as subscribers
- Start Rails apps in clustered mode so that when they interact synchronously they don't block themselves
- Remove explicit calls to /sync endpoints and rely on pub-sub instead