### PR TITLE
CRM457-1366: Use valid MAAT number

### DIFF
--- a/helpers/index.js
+++ b/helpers/index.js
@@ -40,7 +40,7 @@ export const formData = {
     defendant: {
         firstName: 'Lex',
         lastName: 'Luthor',
-        maatId: '1234'
+        maatId: '1234567'
     },
     mainOffenceDate: {
         day: '1',


### PR DESCRIPTION
I'm about to merge a Provider PR that adds stricter validation to MAAT numbers - they must comprise 7 digits.