### PR TITLE
CRM457-1383: Remove firm account number

### DIFF
--- a/e2e/crm7/pages/provider/your-details.js
+++ b/e2e/crm7/pages/provider/your-details.js
@@ -7,7 +7,6 @@ export default class YourDetailsPage {
 
     async fillYourDetails() {
         await this.page.getByLabel('Firm name').fill(formData.firmName);
-        await this.page.getByLabel('Firm account number').fill(formData.firmAccountNumber);
         await this.page.getByLabel('Address line 1').fill(formData.addressLine1);
         await this.page.getByLabel('Town or city').fill(formData.townOrCity);
         await this.page.getByLabel('Postcode').fill(formData.postcode);

--- a/helpers/index.js
+++ b/helpers/index.js
@@ -28,7 +28,7 @@ export const formData = {
         year: '2021'
     },
     firmName: 'Test Automate',
-    firmAccountNumber: '12345678',
+    firmAccountNumber: '1A123B',
     addressLine1: '102 Petty France',
     townOrCity: 'London',
     postcode: 'SW1H 9AJ',


### PR DESCRIPTION
This field has been removed and replaced with a new screen. But as the provider chosen is one with a single office code, that screen will be skipped anyway.

Now green because provider change merged