### PR TITLE
CRM457-917: Add documentation on suggested workflow for breakages

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,11 @@ export LOCAL_PLATFORM=linux/amd64
 _If you want a more manual approach you can build and shell into the test runner container and run them from there_
 
 ```sh
-export DOCKER_BUILDKIT=0
+# build locally on macos intel chipset
+DOCKER_BUILDKIT=0 docker-compose -f docker-compose.yml -f docker-compose.local.yml up -d --build
 
-# build locally
-docker-compose -f docker-compose.yml -f docker-compose.local.yml up -d --build
+# build locally on macos apple silicon chipset (tested on M1)
+DOCKER_BUILDKIT=1 docker-compose -f docker-compose.yml -f docker-compose.local.yml up -d --build
 
 # shell into e2e test container
 docker-compose run --entrypoint sh laa-crime-forms-end-to-end-tests
@@ -90,7 +91,17 @@ docker-compose run --entrypoint sh laa-crime-forms-end-to-end-tests
 npx playwright test --trace on
 ```
 
-You can extract the trace file if neccessary and upload it to [trace.playwright.dev](https://trace.playwright.dev/) to step through the test output.
+Alternatively, this local build has been wrapped up in a script which you can use as follows:
+
+```sh
+# build and shell into container
+./build_test_local.sh
+
+# run the tests in the container
+npx playwright test --trace on
+```
+
+You can extract the trace file from the container if neccessary and upload it to [trace.playwright.dev](https://trace.playwright.dev/) to step through the test output.
 
 ## Running tests as part of other CI pipeline
 

--- a/README.md
+++ b/README.md
@@ -94,9 +94,10 @@ You can extract the trace file if neccessary and upload it to [trace.playwright.
 
 ## Running tests as part of other CI pipeline
 
-The purpose of the end-to-end tests is to idenitfy breaking changes in the LAA crime form app repositories. To achieve a simple, reusable integration an orb has therefore been published.
+The purpose of the end-to-end tests is to identify breaking changes in the LAA crime form app repositories. To achieve a simple, reusable integration an orb has therefore been published.
 
 - [Integrating end-to-end tests into other pipelines](docs/orb/integration.md)
+- [Suggested workflow for integration breakages](docs/orb/integration.md#suggested-workflow-for-integration-breakages)
 - [Publishing the end-to-end test orb](docs/orb/publishing.md)
 
 ## License

--- a/build_test_local.sh
+++ b/build_test_local.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Exit immediately if there is an error
+set -e
+export DOCKER_FILES="-f docker-compose.yml -f docker-compose.local.yml"
+
+if [[ $(uname -m) == 'arm64' ]];
+then
+  echo "Apple Silicon detected"
+  export DOCKER_BUILDKIT=1
+else
+  export DOCKER_BUILDKIT=0
+fi
+
+function build {
+  docker-compose $DOCKER_FILES up -d --build --pull "always" --force-recreate
+}
+
+function shellin {
+  docker-compose run --entrypoint sh laa-crime-forms-end-to-end-tests
+}
+
+build
+shellin
+# now run `npx playwright test --trace on` in container

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -8,17 +8,20 @@ services:
   nscc-provider:
     platform: ${LOCAL_PLATFORM}
     build: https://github.com/ministryofjustice/laa-submit-crime-forms.git#main
+    pull_policy: always
     volumes:
       - ./tmp/logs/provider:/usr/src/app/log
 
   nscc-caseworker:
     platform: ${LOCAL_PLATFORM}
     build: https://github.com/ministryofjustice/laa-assess-crime-forms.git#main
+    pull_policy: always
     volumes:
       - ./tmp/logs/caseworker:/usr/src/app/log
 
   nscc-appstore:
     platform: ${LOCAL_PLATFORM}
     build: https://github.com/ministryofjustice/laa-crime-application-store.git#main
+    pull_policy: always
     volumes:
       - ./tmp/logs/appstore:/usr/src/app/log

--- a/docs/orb/integration.md
+++ b/docs/orb/integration.md
@@ -98,3 +98,39 @@ As for the branch testing the context is required for ECR repository name and ro
 ```yml
 context: laa-crime-forms-e2e-tests
 ```
+
+## Suggested workflow for integration breakages
+If an integrated run of the e2e tests in another repo occurs you should first identify the cause. 
+
+The cause is likely to fall into one of two areas
+
+- a change to the UI of the app on which the e2e tests failed
+- a change to the payload of the app causing a breakage in the other apps
+
+If the cause is the result of changes to the UI of the app on which the e2e tests failed then a suggested workflow would be:
+
+1. checkout a branch of the end-to-end tests (this repository)
+2. add a commit to the "consuming" app's branch to run the e2e test using the new e2e branch
+
+This is done by amending the `e2e_branch` value to your new branch name:
+
+```sh
+  # Amend the job in the consuming app to point it at the new e2e test suite branch
+  e2e-test-branch:
+    ...
+    steps:
+      - crime-forms-end-to-end-tests/run-e2e-tests:
+          ...
+          e2e_branch: main # Change to work against a fixed e2e test repo branch if needed
+          =>
+          e2e_branch: my-branch-of-e2e-tests
+```
+ 3. Amend the e2e test suite branch to fix the tests
+
+ 4. Have both the comsumer app and e2e test suite pull requests reviewed and approved (ready to go)
+
+ 5. Merge the e2e test suite branch's PR
+ 6. Amend the [already approved] consuming app's PR to change `e2e_branch` back to `main` and then merge as soon as possible *
+
+ \* *you should merge asap so as not to break other consuming app branchs.*
+

--- a/docs/orb/integration.md
+++ b/docs/orb/integration.md
@@ -100,7 +100,8 @@ context: laa-crime-forms-e2e-tests
 ```
 
 ## Suggested workflow for integration breakages
-If an integrated run of the e2e tests in another repo occurs you should first identify the cause. 
+
+If an integrated run of the e2e tests in another repo occurs you should first identify the cause.
 
 The cause is likely to fall into one of two areas
 
@@ -125,12 +126,12 @@ This is done by amending the `e2e_branch` value to your new branch name:
           =>
           e2e_branch: my-branch-of-e2e-tests
 ```
- 3. Amend the e2e test suite branch to fix the tests
 
- 4. Have both the comsumer app and e2e test suite pull requests reviewed and approved (ready to go)
+3.  Amend the e2e test suite branch to fix the tests
 
- 5. Merge the e2e test suite branch's PR
- 6. Amend the [already approved] consuming app's PR to change `e2e_branch` back to `main` and then merge as soon as possible *
+4.  Have both the comsumer app and e2e test suite pull requests reviewed and approved (ready to go)
 
- \* *you should merge asap so as not to break other consuming app branchs.*
+5.  Merge the e2e test suite branch's PR
+6.  Amend the [already approved] consuming app's PR to change `e2e_branch` back to `main` and then merge as soon as possible \*
 
+\* _you should merge asap so as not to break other consuming app branchs._

--- a/run_test_local.sh
+++ b/run_test_local.sh
@@ -3,7 +3,13 @@
 set -e
 export DOCKER_FILES="-f docker-compose.yml -f docker-compose.local.yml"
 
-export DOCKER_BUILDKIT=0
+if [[ $(uname -m) == 'arm64' ]];
+then
+  echo "Apple Silicon detected"
+  export DOCKER_BUILDKIT=1
+else
+  export DOCKER_BUILDKIT=0
+fi
 
 function start_app_store {
   docker-compose $DOCKER_FILES run start_app_store


### PR DESCRIPTION
Document suggested workflows and fix scripts for M1 chipset machines

- Document suggested workflow for fixing e2e test integration breakages
- Amend scripts to work with Apple Silicon M1/2 chipset (arm64) transparently
- Add `pull_image: "always"` to docker compose for local build and test to (attempt) to prevent cached images from not being updated and creating false positives locally