### PR TITLE
CRM457-2999 : Pinned actions to commit SHAs instead of versions

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@4901385134134e04cec5fbe5ddfe3b2c5bd5d976 # v4
         with:
           # Possible values: critical, high, moderate, low 
           fail-on-severity: critical

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -4,11 +4,14 @@ on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   format-code:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: ministryofjustice/github-actions/code-formatter@e08cbcac12ec9c09d867ab2b803d4ea1a87300ad # v18.2.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -39,12 +39,6 @@ jobs:
           repository: ministryofjustice/nsm-e2e-test
           path: e2e-tests
 
-      - name: Install docker-compose
-        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # was latest, pinned to v1.6.0
-        with:
-          packages: docker-compose
-          version: 1.0
-
       # laa-submit-crime-forms
       - name: Configure AWS credentials for laa-submit-crime-forms
         uses: ministryofjustice/laa-reusable-github-actions/.github/actions/ecr-auth@e5500aa20b13a1406fe8a62b8788181a2ca18926
@@ -88,16 +82,16 @@ jobs:
         shell: bash
         working-directory: e2e-tests
         run: |
-          docker-compose build --no-cache
-          docker-compose run start_applications
+          docker compose build --no-cache
+          docker compose run start_applications
 
       - name: Run end-to-end tests
         shell: bash
         working-directory: e2e-tests
-        run: docker-compose run laa-crime-forms-end-to-end-tests
+        run: docker compose run laa-crime-forms-end-to-end-tests
 
       - name: Output container logs on failure
         if: failure()
         shell: bash
         working-directory: e2e-tests
-        run: docker-compose logs
+        run: docker compose logs

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -34,13 +34,13 @@ jobs:
       NSCC_CASEWORKER_IMAGE: ${{ secrets.ECR_REGISTRY_URL }}/${{ vars.ASSESS_DEV_ECR_REPOSITORY }}:${{ inputs.assess-sha }}      
     steps:
       - name: Checkout E2E Test Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           repository: ministryofjustice/nsm-e2e-test
           path: e2e-tests
 
       - name: Install docker-compose
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # was latest, pinned to v1.6.0
         with:
           packages: docker-compose
           version: 1.0


### PR DESCRIPTION
## Description of change

Pinned actions in pipelines to commit SHAs instead of numbered versions

Removed the Docker-Compose install step as it was likely an unapproved action and 'docker compose' is available from the ubuntu-latest Github runner.
Tested by changing the referenced job in e2e-tests.yml to the feature branch.    

[Link to ticket CRM457-2999](https://dsdmoj.atlassian.net/browse/CRM457-2999)

## Notes for reviewer
