### PR TITLE
CRM457-3061: Part 2 - Revert Changes to Commit Refs

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   run-e2e-tests:
     name: Call E2E Tests
-    uses: ministryofjustice/nsm-e2e-test/.github/workflows/run-e2e-tests.yml@321b98dbb3748ab7ba19f2c17c010c19672fdbf2
+    uses: ministryofjustice/nsm-e2e-test/.github/workflows/run-e2e-tests.yml@main
     secrets: inherit
     permissions:
       id-token: write

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -4,18 +4,18 @@ description: "Run end-to-end tests for the LAA crime forms services"
 on:
   workflow_call:
     inputs:
-      submit-sha:
-        description: 'SHA hash of the container image to use for laa-submit-crime-forms'
+      submit-image-name:
+        description: 'Name of the container image to use for laa-submit-crime-forms'
         default: 'latest'
         required: false
         type: string
-      assess-sha:
-        description: 'SHA hash of the container image to use for laa-assess-crime-forms'
-        default: 'branch-7b7c47fac89fcaeb0be1868d93082943cbbc44a2'
+      assess-image-name:
+        description: 'Name of the container image to use for laa-assess-crime-forms'
+        default: 'latest'
         required: false
         type: string
-      appstore-sha:
-        description: 'SHA hash of the container image to use for laa-crime-application-store'
+      appstore-image-name:
+        description: 'Name of the container image to use for laa-crime-application-store'
         default: 'latest'
         required: false
         type: string
@@ -29,9 +29,9 @@ jobs:
       id-token: write
       contents: read
     env:
-      NSCC_PROVIDER_IMAGE: ${{ secrets.ECR_REGISTRY_URL }}/${{ vars.SUBMIT_DEV_ECR_REPOSITORY }}:${{ inputs.submit-sha }}
-      NSCC_APPSTORE_IMAGE: ${{ secrets.ECR_REGISTRY_URL }}/${{ vars.APP_STORE_DEV_ECR_REPOSITORY }}:${{ inputs.appstore-sha }}
-      NSCC_CASEWORKER_IMAGE: ${{ secrets.ECR_REGISTRY_URL }}/${{ vars.ASSESS_DEV_ECR_REPOSITORY }}:${{ inputs.assess-sha }}      
+      NSCC_PROVIDER_IMAGE: ${{ secrets.ECR_REGISTRY_URL }}/${{ vars.SUBMIT_DEV_ECR_REPOSITORY }}:${{ inputs.submit-image-name }}
+      NSCC_APPSTORE_IMAGE: ${{ secrets.ECR_REGISTRY_URL }}/${{ vars.APP_STORE_DEV_ECR_REPOSITORY }}:${{ inputs.appstore-image-name }}
+      NSCC_CASEWORKER_IMAGE: ${{ secrets.ECR_REGISTRY_URL }}/${{ vars.ASSESS_DEV_ECR_REPOSITORY }}:${{ inputs.assess-image-name }}      
     steps:
       - name: Checkout E2E Test Repository
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3


### PR DESCRIPTION

## Description of change

- Revert to using latest image name and change input names to ref name instead of SHA
- [Ref conversation for why pipeline input name was changed](https://mojdt.slack.com/archives/C06AB6RDY2W/p1780056513725299?thread_ts=1780055387.376259&cid=C06AB6RDY2W)

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-3061)

## How to manually test the feature
