### PR TITLE
CRM457-2961: Update E2E selectors for Gov Components v6

### DIFF
--- a/e2e/crm4/scenarios/submit-and-assess-application/provider.spec.js
+++ b/e2e/crm4/scenarios/submit-and-assess-application/provider.spec.js
@@ -15,7 +15,7 @@ import {
 	CheckAnswersPage
 } from '../../pages/provider';
 
-import { authenticateAsProvider, storeLAAReference } from '../../../../helpers';
+import { authenticateAsProvider, getLAAReferenceFromPage, storeLAAReference } from '../../../../helpers';
 
 test.describe('CRM4 - As a Provider', () => {
 
@@ -149,9 +149,7 @@ test.describe('CRM4 - As a Provider', () => {
 
       // Set LAA reference for future use
       let laaReference;
-      const panelLocator = await page.locator('.govuk-panel__body');
-			const panelText = await panelLocator.textContent();
-			laaReference = panelText.split('Your LAA reference number')[1].trim();
+			laaReference = await getLAAReferenceFromPage(page, 'Your LAA reference number');
 			// Store LAA reference using scenario name from fixture
 			await storeLAAReference(page, laaReference, scenarioName);
 

--- a/e2e/crm7/pages/provider/claim-details.js
+++ b/e2e/crm7/pages/provider/claim-details.js
@@ -12,7 +12,7 @@ export default class ClaimDetailsPage {
         await this.page.getByRole('group', { name: 'Did you spend time watching' }).getByLabel('No').check();
         await this.page.getByRole('group', { name: 'Did you do any work before' }).getByLabel('No').check();
         await this.page.getByRole('group', { name: 'Did you do any further work' }).getByLabel('No').check();
-        let workCompletedDate = this.page.locator('.govuk-form-group:has-text("Date work was completed")');
+        let workCompletedDate = this.page.getByRole('group', { name: 'Date work was completed' });
         await workCompletedDate.getByRole('textbox', { name: 'Day' }).fill('1');
         await workCompletedDate.getByRole('textbox', { name: 'Month' }).fill('1');
         await workCompletedDate.getByRole('textbox', { name: 'Year' }).fill('2024');

--- a/e2e/crm7/scenarios/submit-and-assess-claim-with-payment/provider.spec.js
+++ b/e2e/crm7/scenarios/submit-and-assess-claim-with-payment/provider.spec.js
@@ -17,6 +17,7 @@ import {
 import {
     nsmData,
     authenticateAsProvider,
+    getLAAReferenceFromPage,
     storeLAAReference
 } from '../../../../helpers';
 
@@ -191,9 +192,7 @@ test.describe('CRM7 - As a Provider', () => {
 
             // Set LAA reference for future use
             let laaReference;
-            const panelLocator = await page.locator('.govuk-panel__body');
-            const panelText = await panelLocator.textContent();
-            laaReference = panelText.split('Your LAA reference number')[1].trim();
+            laaReference = await getLAAReferenceFromPage(page, 'Your LAA reference number');
             // Store LAA reference using scenario name from fixture
             await storeLAAReference(page, laaReference, scenarioName);
         });

--- a/e2e/payments/scenarios/assigned-counsel-amendment/payments.spec.js
+++ b/e2e/payments/scenarios/assigned-counsel-amendment/payments.spec.js
@@ -1,6 +1,7 @@
 import { test, expect } from '../../../fixtures/global-setup';
 import {
     authenticateAsCaseworker,
+    getLAAReferenceFromPage,
     storeLAAReference, 
     paymentData
 } from '../../../../helpers';
@@ -36,9 +37,7 @@ test.describe('Assigned Counsel Payment with Amendment - As a Caseworker', () =>
 
         //Store LAA reference for future use
         let laaReference;
-        const panelLocator = await page.locator('.govuk-panel__body');
-        const panelText = await panelLocator.textContent();
-        laaReference = panelText.split('Reference:')[1].trim();
+        laaReference = await getLAAReferenceFromPage(page, 'Reference:');
         await storeLAAReference(page, laaReference, scenarioName);
 
         await test.step('Start creating an Assigned Counsel - amendment', async () => {

--- a/e2e/payments/scenarios/assigned-counsel-appeal/payments.spec.js
+++ b/e2e/payments/scenarios/assigned-counsel-appeal/payments.spec.js
@@ -1,6 +1,7 @@
 import { test, expect } from '../../../fixtures/global-setup';
 import {
     authenticateAsCaseworker,
+    getLAAReferenceFromPage,
     storeLAAReference, 
     paymentData
 } from '../../../../helpers';
@@ -36,9 +37,7 @@ test.describe('Assigned Counsel Payment with Appeal - As a Caseworker', () => {
 
         //Store LAA reference for future use
         let laaReference;
-        const panelLocator = await page.locator('.govuk-panel__body');
-        const panelText = await panelLocator.textContent();
-        laaReference = panelText.split('Reference:')[1].trim();
+        laaReference = await getLAAReferenceFromPage(page, 'Reference:');
         await storeLAAReference(page, laaReference, scenarioName);
 
         await test.step('Start creating an Assigned Counsel - appeal', async () => {

--- a/e2e/payments/scenarios/assigned-counsel/payments.spec.js
+++ b/e2e/payments/scenarios/assigned-counsel/payments.spec.js
@@ -1,6 +1,7 @@
 import { test, expect } from '../../../fixtures/global-setup';
 import {
     authenticateAsCaseworker,
+    getLAAReferenceFromPage,
     storeLAAReference
 } from '../../../../helpers';
 import { ClaimTypePage, LinkedClaimPage, SolicitorCodePage, CounselCodePage, ClaimDetailsPage, AcClaimCostsPage } from '../../pages';
@@ -65,9 +66,7 @@ test.describe('Assigned Counsel Payment - As a Caseworker', () => {
 
         //Store LAA reference for future use
         let laaReference;
-        const panelLocator = await page.locator('.govuk-panel__body');
-        const panelText = await panelLocator.textContent();
-        laaReference = panelText.split('Reference:')[1].trim();
+        laaReference = await getLAAReferenceFromPage(page, 'Reference:');
         await storeLAAReference(page, laaReference, scenarioName);
 
         await test.step('View payment', async () => {

--- a/e2e/payments/scenarios/nsm-and-linked-ac/payments.spec.js
+++ b/e2e/payments/scenarios/nsm-and-linked-ac/payments.spec.js
@@ -1,6 +1,7 @@
 import { test, expect } from '../../../fixtures/global-setup';
 import {
     authenticateAsCaseworker,
+    getLAAReferenceFromPage,
     storeLAAReference,
     paymentData
 } from '../../../../helpers';
@@ -57,9 +58,7 @@ test.describe('Non-Standard Magistrates payment with linked AC Payment - As a Ca
 
         //Store LAA reference for future use
         let laaReference;
-        const panelLocator = await page.locator('.govuk-panel__body');
-        const panelText = await panelLocator.textContent();
-        laaReference = panelText.split('Reference:')[1].trim();
+        laaReference = await getLAAReferenceFromPage(page, 'Reference:');
         await storeLAAReference(page, laaReference, scenarioName);
 
         await test.step('View payment', async () => {

--- a/e2e/payments/scenarios/nsm-appeal/payments.spec.js
+++ b/e2e/payments/scenarios/nsm-appeal/payments.spec.js
@@ -1,6 +1,7 @@
 import { test, expect } from '../../../fixtures/global-setup';
 import {
     authenticateAsCaseworker,
+    getLAAReferenceFromPage,
     storeLAAReference, 
     paymentData
 } from '../../../../helpers';
@@ -48,9 +49,7 @@ test.describe('Non-Standard Magistrates original payment with appeal - As a Case
 
         //Store LAA reference for future use
         let laaReference;
-        const panelLocator = await page.locator('.govuk-panel__body');
-        const panelText = await panelLocator.textContent();
-        laaReference = panelText.split('Reference:')[1].trim();
+        laaReference = await getLAAReferenceFromPage(page, 'Reference:');
         await storeLAAReference(page, laaReference, scenarioName);
 
         await test.step('Create linked NSM appeal payment', async () => {

--- a/e2e/payments/scenarios/nsm-linked-amendment/payments.spec.js
+++ b/e2e/payments/scenarios/nsm-linked-amendment/payments.spec.js
@@ -1,6 +1,7 @@
 import { test, expect } from '../../../fixtures/global-setup';
 import {
     authenticateAsCaseworker,
+    getLAAReferenceFromPage,
     storeLAAReference, 
     paymentData
 } from '../../../../helpers';
@@ -48,9 +49,7 @@ test.describe('Non-Standard Magistrates original payment with amendment - As a C
 
         //Store LAA reference for future use
         let laaReference;
-        const panelLocator = await page.locator('.govuk-panel__body');
-        const panelText = await panelLocator.textContent();
-        laaReference = panelText.split('Reference:')[1].trim();
+        laaReference = await getLAAReferenceFromPage(page, 'Reference:');
         await storeLAAReference(page, laaReference, scenarioName);
 
         await test.step('Create linked NSM amendment payment', async () => {

--- a/e2e/payments/scenarios/nsm-supplemental/payments.spec.js
+++ b/e2e/payments/scenarios/nsm-supplemental/payments.spec.js
@@ -1,6 +1,7 @@
 import { test, expect } from '../../../fixtures/global-setup';
 import {
     authenticateAsCaseworker,
+    getLAAReferenceFromPage,
     storeLAAReference, 
     paymentData
 } from '../../../../helpers';
@@ -48,9 +49,7 @@ test.describe('Non-Standard Magistrates original payment with supplemental payme
 
         //Store LAA reference for future use
         let laaReference;
-        const panelLocator = await page.locator('.govuk-panel__body');
-        const panelText = await panelLocator.textContent();
-        laaReference = panelText.split('Reference:')[1].trim();
+        laaReference = await getLAAReferenceFromPage(page, 'Reference:');
         await storeLAAReference(page, laaReference, scenarioName);
 
         await test.step('Create linked NSM supplemental payment', async () => {

--- a/helpers/index.js
+++ b/helpers/index.js
@@ -17,6 +17,8 @@ export {
 // Storage helpers
 export {
     storeLAAReference,
+    extractLAAReference,
+    getLAAReferenceFromPage,
     getLAAReference,
     getScenarioName
 } from './storage';

--- a/helpers/storage.js
+++ b/helpers/storage.js
@@ -15,6 +15,29 @@ export const storeLAAReference = async (page, laaReference, scenarioName, storag
     }
 };
 
+export const extractLAAReference = (text, marker) => {
+    if (!text || !marker) {
+        throw new Error('Text and reference marker are required');
+    }
+
+    const markerIndex = text.indexOf(marker);
+    if (markerIndex === -1) {
+        throw new Error(`Could not find LAA reference marker: ${marker}`);
+    }
+
+    const reference = text.slice(markerIndex + marker.length).trim().split(/\s+/)[0];
+    if (!reference) {
+        throw new Error(`Could not find LAA reference after marker: ${marker}`);
+    }
+
+    return reference;
+};
+
+export const getLAAReferenceFromPage = async (page, marker) => {
+    const pageText = await page.getByRole('main').textContent();
+    return extractLAAReference(pageText, marker);
+};
+
 export const getLAAReference = async (page, scenarioName, storagePath = `./e2e/storage/${scenarioName}-provider-state.json`) => {
     try {
         await page.context().storageState({ path: storagePath });


### PR DESCRIPTION
## Summary

- Update CRM4/CRM7 provider journeys to extract LAA references from visible page content after the Gov Components v6 changes.
- Add shared LAA reference extraction helpers.
- Update payment journeys to use the shared helper.
- Update the CRM7 claim details date selector to target the accessible date group.