### PR TITLE
Revert to referencing main branch when running end to end tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   run-e2e-tests:
     name: Call E2E Tests
-    uses: ministryofjustice/nsm-e2e-test/.github/workflows/run-e2e-tests.yml@7607794f3b9aba31fcceefe706975d64db9711c4
+    uses: ministryofjustice/nsm-e2e-test/.github/workflows/run-e2e-tests.yml@main
     secrets: inherit
     permissions:
       id-token: write

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -11,12 +11,12 @@ on:
         type: string
       assess-image-name:
         description: 'Name of the container image to use for laa-assess-crime-forms'
-        default: 'branch-3706d4d73d21b6378c8a2b17d7fd07fdfdad3b3e'
+        default: 'latest'
         required: false
         type: string
       appstore-image-name:
         description: 'Name of the container image to use for laa-crime-application-store'
-        default: 'branch-650d7c7480ff9adc609870fd618e83fa47b5cdb5'
+        default: 'latest'
         required: false
         type: string
 


### PR DESCRIPTION
## Description of change
Now that [PR 263](https://github.com/ministryofjustice/nsm-e2e-test/pull/263) is merged, the reusable step can utilize the main branch instead of referencing a specific commit