### PR TITLE
Revert E2E Branch version and Assess version back to latest

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   run-e2e-tests:
     name: Call E2E Tests
-    uses: ministryofjustice/nsm-e2e-test/.github/workflows/run-e2e-tests.yml@7d1fa16be0d29c05461cbedf4e94a863d5c68fbc
+    uses: ministryofjustice/nsm-e2e-test/.github/workflows/run-e2e-tests.yml@main
     secrets: inherit
     permissions:
       id-token: write

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -11,7 +11,7 @@ on:
         type: string
       assess-image-name:
         description: 'Name of the container image to use for laa-assess-crime-forms'
-        default: 'branch-d97865c9f0c61902232e9eb38560595cd65b304f'
+        default: 'latest'
         required: false
         type: string
       appstore-image-name:


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-3175)

## Notes for reviewer
Reverts back to defaults for E2E tests now that [Assess Content Changes PR is merged](https://github.com/ministryofjustice/laa-assess-crime-forms/pull/1299)